### PR TITLE
Fix sitemap URL scheme detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.0.1] - 2026-06-07
+
+### Fixed
+
+- Use the current ProcessWire site scheme/root URL for generated sitemap file links instead of forcing `https://`.
+- `robots.txt`, sitemap index entries, dashboard links, and IndexNow key file URLs now respect HTTP sites and installations in a subdirectory.
+
+---
+
 ## [1.0.0] - 2026-03-13
 
 ### Added

--- a/ProcessSitemap.module.php
+++ b/ProcessSitemap.module.php
@@ -80,7 +80,7 @@ class ProcessSitemap extends Process implements Module {
     protected function renderDashboard(Sitemap $sitemap): string {
         $status        = $sitemap->getStatus();
         $cfg           = $this->config;
-        $baseUrl       = 'https://' . $cfg->httpHost;
+        $baseUrl       = $sitemap->getBaseUrl();
         $sitemapUrl    = $baseUrl . '/' . $status['sitemap_dir'] . '/sitemap.xml';
         $csrf          = [
             'name'  => $this->session->CSRF->getTokenName(),

--- a/Sitemap.module.php
+++ b/Sitemap.module.php
@@ -18,7 +18,7 @@ class Sitemap extends WireData implements Module, ConfigurableModule {
             'title'    => 'Sitemap',
             'summary'  => 'XML Sitemap generator with sitemap index, per-template settings, and cron-based auto-regeneration.',
             'author'   => 'Maxim Alex',
-            'version'  => '1.0.0',
+            'version'  => '1.0.1',
             'autoload' => true,
             'singular' => true,
             'icon'     => 'sitemap',
@@ -91,6 +91,20 @@ class Sitemap extends WireData implements Module, ConfigurableModule {
         return $this->loadSettings()[$name] ?? (self::getDefaultSettings()[$name] ?? null);
     }
 
+    /**
+     * Return the current site root URL with the same scheme ProcessWire sees.
+     */
+    public function getBaseUrl(): string {
+        $httpRoot = $this->config->urls->httpRoot ?? '';
+        if ($httpRoot) return rtrim($httpRoot, '/');
+
+        $scheme = !empty($this->config->https) ? 'https' : 'http';
+        $host   = $this->config->httpHost ?: ($_SERVER['HTTP_HOST'] ?? '');
+        $root   = $this->config->urls->root ?? '/';
+
+        return rtrim($scheme . '://' . $host . '/' . trim($root, '/'), '/');
+    }
+
     // -------------------------------------------------------------------------
     // Install / Uninstall
     // -------------------------------------------------------------------------
@@ -151,7 +165,7 @@ class Sitemap extends WireData implements Module, ConfigurableModule {
     public function updateRobotsTxt(): bool {
         $robotsFile  = rtrim($this->config->paths->root, '/') . '/robots.txt';
         $sitemapDir  = trim($this->setting('sitemap_dir') ?: self::DEFAULT_DIR, '/');
-        $sitemapUrl  = 'https://' . $this->config->httpHost . '/' . $sitemapDir . '/sitemap.xml';
+        $sitemapUrl  = $this->getBaseUrl() . '/' . $sitemapDir . '/sitemap.xml';
         $enabled     = (bool)$this->setting('robots_txt_reference');
 
         $existing = file_exists($robotsFile) ? file_get_contents($robotsFile) : "User-agent: *\nAllow: /\n";
@@ -485,7 +499,7 @@ class Sitemap extends WireData implements Module, ConfigurableModule {
 
     protected function writeSitemapIndex(string $filepath, array $files): void {
         $dir     = trim($this->setting('sitemap_dir') ?: self::DEFAULT_DIR, '/');
-        $baseUrl = rtrim('https://' . $this->config->httpHost, '/');
+        $baseUrl = $this->getBaseUrl();
         $xml     = new XMLWriter();
         $xml->openUri($filepath);
         $xml->startDocument('1.0', 'UTF-8');
@@ -553,7 +567,7 @@ class Sitemap extends WireData implements Module, ConfigurableModule {
         $key        = trim($this->setting('indexnow_key'));
         $dir        = trim($this->setting('sitemap_dir') ?: self::DEFAULT_DIR, '/');
         $host       = $this->config->httpHost;
-        $baseUrl    = 'https://' . $host;
+        $baseUrl    = $this->getBaseUrl();
         $keyFileUrl = $baseUrl . '/' . $key . '.txt';
 
         // Collect all page URLs from generated sitemap files


### PR DESCRIPTION
## Summary

- Add a shared `Sitemap::getBaseUrl()` helper that uses ProcessWire's current site root URL and scheme.
- Stop forcing `https://` for generated sitemap file URLs.
- Apply the helper to `robots.txt`, sitemap index entries, dashboard links, and IndexNow key file URLs.
- Bump the module changelog/version to `1.0.1`.

## Root cause

The module built several internal sitemap-related URLs with `https://` plus `$config->httpHost`, so HTTP sites produced HTTPS sitemap references even when ProcessWire was serving the site over HTTP.

## Validation

- `git diff --check`
- `php -l Sitemap.module.php`
- `php -l ProcessSitemap.module.php`